### PR TITLE
Return 403 when user logged in but no permission

### DIFF
--- a/django_basic_auth.py
+++ b/django_basic_auth.py
@@ -33,6 +33,9 @@ def view_or_basicauth(view, request, test_func, realm = "", *args, **kwargs):
                         request.user = user
                         if test_func(request.user):
                             return view(request, *args, **kwargs)
+                        else:
+                            # successfully authenticated but no permission
+                            return HttpResponse(status=403)
 
     # Either they did not provide an authorization header or
     # something in the authorization attempt failed. Send a 401


### PR DESCRIPTION
... otherwise, the server would keep responding with 401 prompts even when valid credentials (for an unauthorized account) are provided.
